### PR TITLE
swarm init extras options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -148,6 +148,12 @@ docker_group_users:
 # swarm cluster doesn't overlap with you infrastructure
 # docker_swarm_network: 10.10.8.0/24
 
+# Custom swarm init args. ex: customize default-addr-pool
+# docker_swarm_init_extra_options: |
+#   --default-addr-pool 10.184.32.0/19 \
+#   --default-addr-pool-mask-length 28
+docker_swarm_init_extra_options: ""
+
 # You can set any interface, that is listened by docker engine.
 # e.g. docker_swarm_interface: "eth1"
 docker_swarm_interface: "{{ ansible_default_ipv4['interface'] }}"

--- a/tasks/setup-swarm-cluster.yml
+++ b/tasks/setup-swarm-cluster.yml
@@ -22,7 +22,7 @@
 - name: Init "Swarm Mode" on the first manager.
   shell: docker swarm init
         --listen-addr {{ docker_swarm_addr }}:{{ docker_swarm_port }}
-        --advertise-addr {{ docker_swarm_addr }}
+        --advertise-addr {{ docker_swarm_addr }} {{ docker_swarm_init_extra_options }}
   when: "docker_info.stdout.find('Swarm: active') == -1
     and inventory_hostname == groups['docker_swarm_manager'][0]"
   tags:


### PR DESCRIPTION
Allow to pass extras arg to swarm init.

ex: customize default-addr-pool

```
docker_swarm_init_extra_options: |
  --default-addr-pool 10.184.32.0/19 \
  --default-addr-pool-mask-length 28
```